### PR TITLE
Bump Min AMS version in new TPRs to 1.01

### DIFF
--- a/trunk/tigcc/ide/MainUnit.pas
+++ b/trunk/tigcc/ide/MainUnit.pas
@@ -1154,7 +1154,7 @@ begin
 							else
 								KernelFormat := kfNone;
 							UseMinAMS                           := ReadBool   ('Library Options', 'Minimum AMS Version Defined',  False);
-							MinAMS                              := ReadString ('Library Options', 'Minimum AMS Version',          '1.00');
+							MinAMS                              := ReadString ('Library Options', 'Minimum AMS Version',          '1.01');
 							UnofficialOSSupport                 := ReadBool   ('Library Options', 'Unofficial OS Support',        False);
 							RelocFormat    := StringToRelocFormat (ReadString ('Library Options', 'Reloc Format',                 ''));
 							ROMCallFormat  := StringToRelocFormat (ReadString ('Library Options', 'ROM Call Format',              ''));


### PR DESCRIPTION
The documentation says that MIN_AMS defaults to 1.01, but new TPR files are still created with MIN_AMS = 1.00. This creates a confusing situation where the IDE compiles code directly but attempting to use tprbuilder on Linux will fail, because it reads "Minimum AMS Version" out of the tpr as 1.00.
